### PR TITLE
Optionally render wallet explanation and set default description

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,17 +9,77 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@ledgerhq/hw-transport-webhid": "^6.20.0",
+        "@ledgerhq/hw-transport-webusb": "^6.20.0",
         "@types/react": "^17.0.37",
         "@types/react-dom": "^17.0.11",
+        "bs58": "^4.0.1",
         "near-api-js": "^0.44.1",
-        "process": "^0.11.10",
         "react": "^17.0.2",
         "react-dom": "^17.0.2"
       },
       "devDependencies": {
+        "@ledgerhq/logs": "^6.10.0",
         "@types/bn.js": "^5.1.0",
+        "@types/bs58": "^4.0.1",
+        "@types/node": "^16.11.13",
+        "@types/w3c-web-hid": "^1.0.2",
+        "@types/w3c-web-usb": "^1.0.5",
         "typescript": "^4.5.3"
       }
+    },
+    "node_modules/@ledgerhq/devices": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-6.20.0.tgz",
+      "integrity": "sha512-WehM7HGdb+nSUzyUlz1t2qJ8Tg4I+rQkOJJsx0/Dpjkx6/+1hHcX6My/apPuwh39qahqwYhjszq0H1YzGDS0Yg==",
+      "dependencies": {
+        "@ledgerhq/errors": "^6.10.0",
+        "@ledgerhq/logs": "^6.10.0",
+        "rxjs": "6",
+        "semver": "^7.3.5"
+      }
+    },
+    "node_modules/@ledgerhq/errors": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-6.10.0.tgz",
+      "integrity": "sha512-fQFnl2VIXh9Yd41lGjReCeK+Q2hwxQJvLZfqHnKqWapTz68NHOv5QcI0OHuZVNEbv0xhgdLhi5b65kgYeQSUVg=="
+    },
+    "node_modules/@ledgerhq/hw-transport": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-6.20.0.tgz",
+      "integrity": "sha512-5KS0Y6CbWRDOv3FgNIfk53ViQOIZqMxAw0RuOexreW5GMwuYfK7ddGi4142qcu7YrxkGo7cNe42wBbx1hdXl0Q==",
+      "dependencies": {
+        "@ledgerhq/devices": "^6.20.0",
+        "@ledgerhq/errors": "^6.10.0",
+        "events": "^3.3.0"
+      }
+    },
+    "node_modules/@ledgerhq/hw-transport-webhid": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-webhid/-/hw-transport-webhid-6.20.0.tgz",
+      "integrity": "sha512-vpbeKmvlQQHQIT7MOAt8TJV7706YkvfEsW2it/vQKAKGjmAYWgrLDXLLgmA1rEDschq0w63crOSp0El4doy+JQ==",
+      "dependencies": {
+        "@ledgerhq/devices": "^6.20.0",
+        "@ledgerhq/errors": "^6.10.0",
+        "@ledgerhq/hw-transport": "^6.20.0",
+        "@ledgerhq/logs": "^6.10.0"
+      }
+    },
+    "node_modules/@ledgerhq/hw-transport-webusb": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-webusb/-/hw-transport-webusb-6.20.0.tgz",
+      "integrity": "sha512-7rtgOEuEZ7/O5JofcglUVck7RXH5D8vS3zP5SjPURhvSFiJVGrtOVS+Qna7gXqGdkesDcNF0xBkwme+67n4Imw==",
+      "dependencies": {
+        "@ledgerhq/devices": "^6.20.0",
+        "@ledgerhq/errors": "^6.10.0",
+        "@ledgerhq/hw-transport": "^6.20.0",
+        "@ledgerhq/logs": "^6.10.0"
+      }
+    },
+    "node_modules/@ledgerhq/logs": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-6.10.0.tgz",
+      "integrity": "sha512-lLseUPEhSFUXYTKj6q7s2O3s2vW2ebgA11vMAlKodXGf5AFw4zUoEbTz9CoFOC9jS6xY4Qr8BmRnxP/odT4Uuw=="
     },
     "node_modules/@types/bn.js": {
       "version": "5.1.0",
@@ -28,6 +88,15 @@
       "dev": true,
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-yfAgiWgVLjFCmRv8zAcOIHywYATEwiTVccTLnRp6UxTNavT55M9d/uhK3T03St/+8/z/wW+CRjGKUNmEqoHHCA==",
+      "dev": true,
+      "dependencies": {
+        "base-x": "^3.0.6"
       }
     },
     "node_modules/@types/node": {
@@ -63,6 +132,18 @@
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
       "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
+    },
+    "node_modules/@types/w3c-web-hid": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/w3c-web-hid/-/w3c-web-hid-1.0.2.tgz",
+      "integrity": "sha512-tNLnl6+/AkmASEnviwdLLE6kaXlY28cDVyQ3e+WwnEAm5DHyO7c71a5TtYX6ofrnzzdQSnNsjNMoggsbrtOYfQ==",
+      "dev": true
+    },
+    "node_modules/@types/w3c-web-usb": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/w3c-web-usb/-/w3c-web-usb-1.0.5.tgz",
+      "integrity": "sha512-dYolx2XWesl1TMu+1BjtjU6eC6c2zZ2VDKhjU4f/mtR3+UBfMW6h1tPCQt7leY5Y8JBg0Fe/mMnoDMkPPNX9sw==",
+      "dev": true
     },
     "node_modules/base-x": {
       "version": "3.0.9",
@@ -123,6 +204,14 @@
         "u3": "^0.1.1"
       }
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/http-errors": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
@@ -170,6 +259,17 @@
       },
       "bin": {
         "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/mustache": {
@@ -225,14 +325,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
     "node_modules/react": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
@@ -256,6 +348,17 @@
       },
       "peerDependencies": {
         "react": "17.0.2"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "dependencies": {
+        "tslib": "^1.9.0"
+      },
+      "engines": {
+        "npm": ">=2.0.0"
       }
     },
     "node_modules/safe-buffer": {
@@ -284,6 +387,20 @@
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/setprototypeof": {
@@ -316,6 +433,11 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+    },
+    "node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/tweetnacl": {
       "version": "1.0.3",
@@ -353,6 +475,11 @@
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
       }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     }
   },
   "dependencies": {
@@ -627,11 +754,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-    },
-    "process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
     },
     "react": {
       "version": "17.0.2",

--- a/src/modal/component/Modal/Modal.styles.ts
+++ b/src/modal/component/Modal/Modal.styles.ts
@@ -11,6 +11,10 @@ export default `
   align-items: center;
 }
 
+.Modal * {
+box-sizing: content-box;
+}
+
 .Modal .Modal-content {
   max-width: 700px;
   max-height: 70vh;
@@ -20,6 +24,11 @@ export default `
   border-radius: 16px;
   padding: 1.5em;
   overflow-y: auto;
+}
+
+.Modal-option-list li span,
+.Modal .Modal-content p {
+    font-size: 16px;
 }
 
 .Modal-header {

--- a/src/modal/component/Modal/Modal.tsx
+++ b/src/modal/component/Modal/Modal.tsx
@@ -11,6 +11,7 @@ function Modal(): JSX.Element {
   const [ledgerWalletError, setLedgerWalletError] = useState("");
   const [useCustomDerivationPath, setUseCustomDerivationPath] = useState(false);
   const [walletInfoVisible, setWalletInfoVisible] = useState(false);
+  const defaultDescription = "Please select a wallet to connect to this dapp:";
 
   const mountedStyle = {
     animation: "inAnimation 350ms ease-in",
@@ -72,7 +73,9 @@ function Modal(): JSX.Element {
       >
         <div className="Modal-content">
           <div className="Modal-body Modal-select-wallet-option">
-            <p>Please select a wallet to connect to this dapp:</p>
+            <p>
+              {State.options.walletSelectorUI.description || defaultDescription}
+            </p>
             <ul className="Modal-option-list">
               {State.options.wallets.map((wallet: string) => {
                 if (!State.walletProviders[wallet]) return null;
@@ -159,26 +162,23 @@ function Modal(): JSX.Element {
               </button>
             </div>
           </div>
-          <div className="info">
-            <span
-              onClick={() => {
-                setWalletInfoVisible(!walletInfoVisible);
-              }}
-            >
-              What is a Wallet?
-            </span>
-            <div
-              className="info-description"
-              style={walletInfoVisible ? mountedStyle : unmountedStyle}
-            >
-              <p>
-                Wallets are used to send, receive, and store digital assets.
-                There are different types of wallets. They can be an extension
-                added to your browser, a hardware device plugged into your
-                computer, web-based, or as an app on your phone.
-              </p>
+          {State.options.walletSelectorUI.explanation && (
+            <div className="info">
+              <span
+                onClick={() => {
+                  setWalletInfoVisible(!walletInfoVisible);
+                }}
+              >
+                What is a Wallet?
+              </span>
+              <div
+                className="info-description"
+                style={walletInfoVisible ? mountedStyle : unmountedStyle}
+              >
+                <p>{State.options.walletSelectorUI.explanation}</p>
+              </div>
             </div>
-          </div>
+          )}
         </div>
       </div>
     </div>

--- a/src/state/State.ts
+++ b/src/state/State.ts
@@ -7,6 +7,10 @@ const State: State = {
     networkId: "testnet",
     wallets: ["nearwallet", "senderwallet", "ledgerwallet"],
     customWallets: {},
+    walletSelectorUI: {
+      description: "",
+      explanation: "",
+    },
   },
   walletProviders: {},
   isSignedIn: localStorage.getItem(LOCALSTORAGE_SIGNED_IN_WALLET_KEY) !== null,

--- a/src/types/Options.ts
+++ b/src/types/Options.ts
@@ -7,6 +7,10 @@ type Options = {
     [name: string]: CustomWalletOptions;
   };
   theme: "dark" | "light" | null;
+  walletSelectorUI: {
+    description: string;
+    explanation: string;
+  };
 };
 
 export default Options;


### PR DESCRIPTION
When we initialize the wallet-selector now we can the walletSelectorUI object (option) to optionally render elements in `modal.`

```
walletSelectorUI: {
   description: string,
   explanation: string,
}
```

```
const near = new NearWalletSelector({
    wallets: ["nearwallet", "senderwallet", "ledgerwallet", "mywallet"],
    networkId: "testnet",
    theme: "light",
    walletSelectorUI: {
        description: 'Please select a wallet to connect to this dapp (custom-desc):',
        explanation: 'Explain what is a wallet here...',
    }
});
```