### PR TITLE
Show wallet explanation in example dapp

### DIFF
--- a/example/src/index.js
+++ b/example/src/index.js
@@ -19,6 +19,12 @@ async function initContract() {
       viewMethods: ["getMessages"],
       changeMethods: ["addMessage"],
     },
+    walletSelectorUI: {
+      description: "Please select a wallet to connect to this dapp:",
+      explanation: `Wallets are used to send, receive, and store digital assets. There are different types of wallets. 
+                  They can be an extension added to your browser, a hardware device plugged into your computer, 
+                  web-based, or as an app on your phone.`,
+    },
   });
 
   // Load in user's account data


### PR DESCRIPTION
Added walletSelectorUI object to the options when we initalize the wallet-selector.

- Provided a custom `description` and `explanation` so they can be shown in the UI.
