### PR TITLE
#115 Migrate Async Init

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The NEAR Wallet Selector makes it easy for users to interact with your dApp. This package presents a modal to switch between a number of supported wallet types:
 
 - [NEAR Wallet](https://wallet.near.org/) - Web wallet.
-- [Sender](https://chrome.google.com/webstore/detail/sender-wallet/epapihdplajcdnnkdeiahlgigofloibg) - Browser extension wallet.
+- [Sender Wallet](https://chrome.google.com/webstore/detail/sender-wallet/epapihdplajcdnnkdeiahlgigofloibg) - Browser extension wallet.
 - [Ledger](https://www.ledger.com/) - Hardware wallet.
 
 ## Installation and Usage
@@ -19,7 +19,7 @@ Then use it in your dApp:
 ```ts
 import NearWalletSelector from "near-walletselector";
 
-const near = await NearWalletSelector({
+const near = new NearWalletSelector({
   wallets: ["nearwallet", "senderwallet", "ledgerwallet"],
   networkId: "testnet",
   theme: "light",
@@ -42,6 +42,12 @@ const near = await NearWalletSelector({
 
 ## API Reference
 
+Init:
+
+```ts
+await near.init();
+```
+
 Show modal:
 
 ```ts
@@ -63,13 +69,13 @@ near.isSignedIn();
 Sign out:
 
 ```ts
-near.signOut();
+await near.signOut();
 ```
 
-Add event listeners (init, disconnect, signIn):
+Add event listeners (disconnect, signIn):
 
 ```ts
-near.on("init", () => {
+near.on("signIn", () => {
    // your code
 });
 ```
@@ -77,13 +83,12 @@ near.on("init", () => {
 Interact with smart contract:
 
 ```ts
-const contract = near.getContract();
 
 // Retrieve messages via RPC endpoint (view method).
-const messages = await contract.view({ methodName: "getMessages" });
+const messages = await near.contract.view({ methodName: "getMessages" });
 
 // Send a message, modifying the blockchain (change method).
-await contract.call({
+await near.contract.call({
   actions: [{
     methodName: "addMessage",
     args: { text: message.value },

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -32,7 +32,7 @@ const App = ({ near, initialAccount }) => {
         });
     });
 
-    near.on("disconnected", async () => {
+    near.on("disconnected", () => {
       console.log("'disconnect' event triggered!");
       setAccount(null);
     });
@@ -85,13 +85,19 @@ const App = ({ near, initialAccount }) => {
       });
   };
 
-  const signIn = async () => {
+  const signIn = () => {
     near.showModal();
   };
 
-  const signOut = async () => {
-    near.signOut();
-    window.location.replace(window.location.origin + window.location.pathname);
+  const signOut = () => {
+    near.signOut()
+      .then(() => {
+        window.location.replace(window.location.origin + window.location.pathname);
+      })
+      .catch((err) => {
+        console.log("Failed to sign out");
+        console.error(err);
+      });
   };
 
   function switchProviderHandler() {

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -10,7 +10,7 @@ async function initContract() {
   // based on the network ID we pass to getConfig()
   const nearConfig = getConfig(process.env.NEAR_ENV || "testnet");
 
-  const near = await NearWalletSelector({
+  const near = new NearWalletSelector({
     wallets: ["nearwallet", "senderwallet", "ledgerwallet"],
     networkId: "testnet",
     theme: "light",
@@ -26,29 +26,24 @@ async function initContract() {
     },
   });
 
-  // Load in user's account data
-  near.on("init", async () => {
-    console.log("init");
-  });
-
-  let currentUser = await near.getAccount();
-  console.log(currentUser);
+  await near.init();
 
   return {
     near,
-    contract: near.contract,
-    currentUser,
-    nearConfig
+    initialAccount: await near.getAccount(),
   };
 }
 
 window.onload = () => {
-  window.nearInitPromise = initContract().then(
-    ({ near, contract, currentUser }) => {
+  initContract()
+    .then(({ near, initialAccount }) => {
       ReactDOM.render(
-        <App near={near} contract={contract} currentUser2={currentUser} />,
+        <App near={near} initialAccount={initialAccount} />,
         document.getElementById("root")
       );
-    }
-  );
+    })
+    .catch((err) => {
+      console.log("Failed to initialise at root");
+      console.error(err);
+    });
 };

--- a/src/controllers/WalletController.ts
+++ b/src/controllers/WalletController.ts
@@ -109,7 +109,6 @@ class WalletController {
   async getAccount() {
     const state = getState();
 
-    console.log("getAccount", { state });
     if (state.signedInWalletId !== null) {
       return state.walletProviders[state.signedInWalletId].getAccount();
     }

--- a/src/controllers/WalletController.ts
+++ b/src/controllers/WalletController.ts
@@ -108,6 +108,8 @@ class WalletController {
 
   async getAccount() {
     const state = getState();
+
+    console.log("getAccount", { state });
     if (state.signedInWalletId !== null) {
       return state.walletProviders[state.signedInWalletId].getAccount();
     }

--- a/src/core/NearWalletSelector.tsx
+++ b/src/core/NearWalletSelector.tsx
@@ -30,7 +30,6 @@ export default class NearWalletSelector {
       }));
     }
 
-    const state = getState();
     const config = getConfig(options.networkId);
 
     this.emitter = new EventHandler();
@@ -38,9 +37,13 @@ export default class NearWalletSelector {
     this.walletController = new WalletController(this.emitter, this.provider);
 
     this.contract = new Contract(options.accountId, this.provider);
+  }
 
-    if (state.signedInWalletId !== null) {
-      state.walletProviders[state.signedInWalletId].init();
+  async init() {
+    const state = getState();
+
+    if (state.signedInWalletId) {
+      await state.walletProviders[state.signedInWalletId].init();
     }
 
     this.renderModal();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,21 +1,3 @@
 import NearWalletSelector from "./core/NearWalletSelector";
-import getConfig from "./config";
-import { connect, keyStores } from "near-api-js";
-import { updateState } from "./state/State";
-import Options from "./types/Options";
 
-export default async function init(options: Options) {
-  const nearConfig = getConfig(options.networkId);
-  const keyStore = new keyStores.BrowserLocalStorageKeyStore();
-
-  const nearConnection = await connect({
-    keyStore,
-    ...nearConfig,
-    headers: {},
-  });
-  updateState((prevState) => ({
-    ...prevState,
-    nearConnection,
-  }));
-  return new NearWalletSelector(options);
-}
+export default NearWalletSelector;

--- a/src/state/State.ts
+++ b/src/state/State.ts
@@ -23,7 +23,6 @@ const state: { current: State } = {
     isSignedIn:
       localStorage.getItem(LOCALSTORAGE_SIGNED_IN_WALLET_KEY) !== null,
     signedInWalletId: localStorage.getItem(LOCALSTORAGE_SIGNED_IN_WALLET_KEY),
-    nearConnection: null,
   },
 };
 

--- a/src/types/EventList.ts
+++ b/src/types/EventList.ts
@@ -1,3 +1,3 @@
-type EventList = "disconnect" | "signIn" | "test";
+type EventList = "disconnect" | "signIn";
 
 export default EventList;

--- a/src/types/State.ts
+++ b/src/types/State.ts
@@ -1,6 +1,5 @@
 import Options from "./Options";
 import IWallet from "../interfaces/IWallet";
-import { Near } from "near-api-js";
 
 type State = {
   showModal: boolean;
@@ -14,7 +13,6 @@ type State = {
   };
   isSignedIn: boolean;
   signedInWalletId: string | null;
-  nearConnection: Near | null;
 };
 
 export default State;

--- a/src/utils/__tests__/EventEmitter.spec.ts
+++ b/src/utils/__tests__/EventEmitter.spec.ts
@@ -3,7 +3,7 @@ import { EventHandler } from "../EventsHandler";
 describe("emit", () => {
   it("calls the subscribed handlers for the event", () => {
     const emitter = new EventHandler();
-    const event = "test";
+    const event = "signIn";
     const handler = jest.fn();
     emitter.on(event, handler);
     emitter.emit(event);
@@ -12,7 +12,7 @@ describe("emit", () => {
 
   it("calls the subscribed handlers with data for the event", () => {
     const emitter = new EventHandler();
-    const event = "test";
+    const event = "signIn";
     const data = { value: "test" };
     const handler = jest.fn();
     emitter.on(event, handler);
@@ -23,7 +23,7 @@ describe("emit", () => {
 
   it("calls the multiple subscribed handlers with data for the event", () => {
     const emitter = new EventHandler();
-    const event = "test";
+    const event = "signIn";
     const data = { value: "test" };
     const handler = jest.fn();
     const secondHandler = jest.fn();
@@ -40,7 +40,7 @@ describe("emit", () => {
 describe("off", () => {
   it("doesn't call the handler after unsubscribing", () => {
     const emitter = new EventHandler();
-    const event = "test";
+    const event = "signIn";
     const handler = jest.fn();
     emitter.on(event, handler);
     emitter.off(event, handler);

--- a/src/wallets/browser/NearWallet.ts
+++ b/src/wallets/browser/NearWallet.ts
@@ -1,4 +1,9 @@
-import { WalletConnection, transactions } from "near-api-js";
+import {
+  WalletConnection,
+  transactions,
+  connect,
+  keyStores,
+} from "near-api-js";
 import BN from "bn.js";
 
 import BrowserWallet from "../types/BrowserWallet";
@@ -11,6 +16,7 @@ import {
   FunctionCallAction,
 } from "../../interfaces/IWallet";
 import ProviderService from "../../services/provider/ProviderService";
+import getConfig from "../../config";
 
 class NearWallet extends BrowserWallet implements INearWallet {
   private wallet: WalletConnection;
@@ -34,12 +40,13 @@ class NearWallet extends BrowserWallet implements INearWallet {
 
   async init() {
     const state = getState();
+    const near = await connect({
+      keyStore: new keyStores.BrowserLocalStorageKeyStore(),
+      ...getConfig(state.options.networkId),
+      headers: {},
+    });
 
-    if (!state.nearConnection) {
-      return;
-    }
-
-    this.wallet = new WalletConnection(state.nearConnection, "near_app");
+    this.wallet = new WalletConnection(near, "near_app");
 
     if (this.wallet.isSignedIn()) {
       this.setWalletAsSignedIn();

--- a/src/wallets/injected/SenderWallet.ts
+++ b/src/wallets/injected/SenderWallet.ts
@@ -37,16 +37,14 @@ class SenderWallet extends InjectedWallet implements ISenderWallet {
     const state = getState();
 
     this.wallet.onAccountChanged((newAccountId) => {
-      console.log("newAccountId: ", newAccountId);
+      console.log("SenderWallet:onAccountChange", newAccountId);
     });
 
     this.onNetworkChanged();
 
     return this.wallet
       .init({ contractId: state.options.accountId })
-      .then((res) => {
-        console.log(res);
-      });
+      .then((res) => console.log("SenderWallet:init", res));
   }
 
   async walletSelected() {

--- a/src/wallets/injected/SenderWallet.ts
+++ b/src/wallets/injected/SenderWallet.ts
@@ -31,6 +31,24 @@ class SenderWallet extends InjectedWallet implements ISenderWallet {
     this.wallet = window.wallet!;
   }
 
+  async init(): Promise<void> {
+    await this.timeout(200);
+
+    const state = getState();
+
+    this.wallet.onAccountChanged((newAccountId) => {
+      console.log("newAccountId: ", newAccountId);
+    });
+
+    this.onNetworkChanged();
+
+    return this.wallet
+      .init({ contractId: state.options.accountId })
+      .then((res) => {
+        console.log(res);
+      });
+  }
+
   async walletSelected() {
     if (!this.wallet) {
       updateState((prevState) => ({
@@ -74,24 +92,6 @@ class SenderWallet extends InjectedWallet implements ISenderWallet {
 
   async timeout(ms: number) {
     return new Promise((resolve) => setTimeout(resolve, ms));
-  }
-
-  async init(): Promise<void> {
-    await this.timeout(200);
-
-    const state = getState();
-
-    this.wallet.onAccountChanged((newAccountId) => {
-      console.log("newAccountId: ", newAccountId);
-    });
-
-    this.onNetworkChanged();
-
-    return this.wallet
-      .init({ contractId: state.options.accountId })
-      .then((res) => {
-        console.log(res);
-      });
   }
 
   onNetworkChanged() {


### PR DESCRIPTION
## This PR Includes

- Reverted back to instantiating the `NearWalletSelector` class.
- Moved `WalletConnection` logic into `NearWallet` class.
- Updated example project.
- Updated README to reflect API changes.
- Fixed regression in #100 where there was an old `state.walletProviders` reference which caused the `init` wallet method to fail when previously logged in.