### PR TITLE
Handle account change in Sender Wallet

### DIFF
--- a/example/src/App.js
+++ b/example/src/App.js
@@ -32,7 +32,7 @@ const App = ({ near, initialAccount }) => {
         });
     });
 
-    near.on("disconnected", () => {
+    near.on("disconnect", () => {
       console.log("'disconnect' event triggered!");
       setAccount(null);
     });

--- a/src/interfaces/InjectedSenderWallet.ts
+++ b/src/interfaces/InjectedSenderWallet.ts
@@ -5,16 +5,23 @@ export interface InitParams {
 }
 
 // Empty string if we haven't signed in before.
+interface AccessKey {
+  publicKey: {
+    data: Uint8Array;
+    keyType: number;
+  };
+  secretKey: string;
+}
+
 export interface InitResponse {
-  accessKey:
-    | ""
-    | {
-        publicKey: {
-          data: Uint8Array;
-          keyType: number;
-        };
-        secretKey: string;
-      };
+  accessKey: AccessKey | "";
+}
+
+export interface RequestSignInResponse {
+  accessKey: AccessKey;
+  error: string;
+  notificationId: number;
+  type: "sender-wallet-result";
 }
 
 export interface RpcInfo {
@@ -97,7 +104,9 @@ interface InjectedSenderWallet {
   init: (params: InitParams) => Promise<InitResponse>;
   getAccountId: () => string;
   getRpc: () => Promise<GetRpcResponse>;
-  requestSignIn: (params: RequestSignInParams) => Promise<InitResponse>;
+  requestSignIn: (
+    params: RequestSignInParams
+  ) => Promise<RequestSignInResponse>;
   signOut: () => Promise<SignOutResponse>;
   isSignedIn: () => boolean;
   onAccountChanged: (callback: AccountChangedCallback) => void;

--- a/src/wallets/injected/SenderWallet.ts
+++ b/src/wallets/injected/SenderWallet.ts
@@ -69,11 +69,11 @@ class SenderWallet extends InjectedWallet implements ISenderWallet {
 
   async signIn() {
     const state = getState();
-    const { accessKey } = await this.wallet.requestSignIn({
+    const response = await this.wallet.requestSignIn({
       contractId: state.options.accountId,
     });
 
-    if (!accessKey) {
+    if (response.error) {
       if (this.wallet.isSignedIn()) await this.disconnect();
       return;
     }

--- a/src/wallets/injected/SenderWallet.ts
+++ b/src/wallets/injected/SenderWallet.ts
@@ -36,9 +36,7 @@ class SenderWallet extends InjectedWallet implements ISenderWallet {
 
     const state = getState();
 
-    this.wallet.onAccountChanged((newAccountId) => {
-      console.log("SenderWallet:onAccountChange", newAccountId);
-    });
+    this.onAccountChanged();
 
     this.onNetworkChanged();
 
@@ -78,7 +76,6 @@ class SenderWallet extends InjectedWallet implements ISenderWallet {
     }
 
     await this.setWalletAsSignedIn();
-    this.emitter.emit("signIn");
 
     this.emitter.emit("signIn");
 
@@ -110,6 +107,26 @@ class SenderWallet extends InjectedWallet implements ISenderWallet {
       return false;
     }
     return true;
+  }
+
+  onAccountChanged() {
+    this.wallet.onAccountChanged((newAccountId) => {
+      console.log("SenderWallet:onAccountChange", newAccountId);
+
+      const state = getState();
+
+      this.wallet
+        .init({
+          contractId: state.options.accountId,
+        })
+        .then((response) => {
+          if (response.accessKey) {
+            this.emitter.emit("signIn");
+          } else {
+            this.signIn().then();
+          }
+        });
+    });
   }
 
   async isConnected() {

--- a/src/wallets/injected/SenderWallet.ts
+++ b/src/wallets/injected/SenderWallet.ts
@@ -116,19 +116,7 @@ class SenderWallet extends InjectedWallet implements ISenderWallet {
     this.wallet.onAccountChanged((newAccountId) => {
       console.log("SenderWallet:onAccountChange", newAccountId);
 
-      const state = getState();
-
-      this.wallet
-        .init({
-          contractId: state.options.accountId,
-        })
-        .then((response) => {
-          if (response.accessKey) {
-            this.emitter.emit("signIn");
-          } else {
-            this.signIn().then();
-          }
-        });
+      this.signIn();
     });
   }
 

--- a/src/wallets/injected/SenderWallet.ts
+++ b/src/wallets/injected/SenderWallet.ts
@@ -74,8 +74,7 @@ class SenderWallet extends InjectedWallet implements ISenderWallet {
     });
 
     if (response.error) {
-      if (this.wallet.isSignedIn()) await this.disconnect();
-      return;
+      throw new Error(`Failed to sign in: ${response.error}`);
     }
 
     await this.setWalletAsSignedIn();
@@ -113,10 +112,15 @@ class SenderWallet extends InjectedWallet implements ISenderWallet {
   }
 
   onAccountChanged() {
-    this.wallet.onAccountChanged((newAccountId) => {
+    this.wallet.onAccountChanged(async (newAccountId) => {
       console.log("SenderWallet:onAccountChange", newAccountId);
+      try {
+        await this.disconnect();
 
-      this.signIn();
+        await this.signIn();
+      } catch (e) {
+        console.log(`Failed to change account ${e.message}`);
+      }
     });
   }
 

--- a/src/wallets/injected/SenderWallet.ts
+++ b/src/wallets/injected/SenderWallet.ts
@@ -72,6 +72,7 @@ class SenderWallet extends InjectedWallet implements ISenderWallet {
     });
 
     if (!accessKey) {
+      if (this.wallet.isSignedIn()) await this.disconnect();
       return;
     }
 


### PR DESCRIPTION
## This PR includes

- Listen to the onAccountChanged event emited by Sender Wallet
- If the current selected account is not signed in prompt user to connect dApp with the newly selected account.
- If user rejects fire event "disconnect" to inform dApp
- Fixed typo in example dApp when listening on the `"disconnect"` event.

## Notes

I tried many different ways to handle the case when user rejects (closes the sender wallet popup window) during the process when a new account is selected inside the Sender Wallet the best I could come up was to call the `disconnect`in which case the dApp sets account to null.