### PR TITLE
Rename package to "near-wallet-selector"

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,16 @@ The NEAR Wallet Selector makes it easy for users to interact with your dApp. Thi
 
 ## Installation and Usage
 
-The easiest way to use `near-walletselector` is to install it from NPM:
+The easiest way to use `near-wallet-selector` is to install it from NPM:
 
 ```bash
-npm install near-walletselector
+npm install near-wallet-selector
 ```
 
 Then use it in your dApp:
 
 ```ts
-import NearWalletSelector from "near-walletselector";
+import NearWalletSelector from "near-wallet-selector";
 
 const near = new NearWalletSelector({
   wallets: ["nearwallet", "senderwallet", "ledgerwallet"],

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -12,7 +12,7 @@
         "big.js": "^6.1.1",
         "env-cmd": "^10.1.0",
         "near-api-js": "0.44.2",
-        "near-walletselector": "file:../",
+        "near-wallet-selector": "file:../",
         "prop-types": "^15.7.2",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
@@ -39,7 +39,7 @@
       }
     },
     "..": {
-      "name": "near-walletselector",
+      "name": "near-wallet-selector",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
@@ -15242,7 +15242,7 @@
         "near-vm": "run.js"
       }
     },
-    "node_modules/near-walletselector": {
+    "node_modules/near-wallet-selector": {
       "resolved": "..",
       "link": true
     },
@@ -33463,7 +33463,7 @@
         "binary-install": "^0.0.1"
       }
     },
-    "near-walletselector": {
+    "near-wallet-selector": {
       "version": "file:..",
       "requires": {
         "@ledgerhq/hw-transport-webhid": "^6.20.0",

--- a/example/package.json
+++ b/example/package.json
@@ -41,7 +41,7 @@
     "big.js": "^6.1.1",
     "env-cmd": "^10.1.0",
     "near-api-js": "0.44.2",
-    "near-walletselector": "file:../",
+    "near-wallet-selector": "file:../",
     "prop-types": "^15.7.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -2,7 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import App from "./App";
 import getConfig from "./config.js";
-import NearWalletSelector from "near-walletselector";
+import NearWalletSelector from "near-wallet-selector";
 
 // Initializing contract
 async function initContract() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "near-walletselector",
+  "name": "near-wallet-selector",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "near-walletselector",
+      "name": "near-wallet-selector",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "near-walletselector",
+  "name": "near-wallet-selector",
   "version": "1.0.0",
   "description": "This is a wallet modal that allows users to interact with NEAR dApps with a selection of available wallets.",
   "main": "./lib/cjs/index.js",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,3 @@
-export const MODAL_ELEMENT_ID = "near-walletselector-modal";
-export const LOCALSTORAGE_SIGNED_IN_WALLET_KEY = "near-walletselector-signedin";
+export const MODAL_ELEMENT_ID = "near-wallet-selector-modal";
+export const LOCALSTORAGE_SIGNED_IN_WALLET_KEY =
+  "near-wallet-selector-signedin";


### PR DESCRIPTION
## This PR includes

- Renamed package from `"near-walletselector"` to `"near-wallet-selector"`.
- Updated `README` to reflect new package name.
- Updated `example `dApp to reflect the new package name.
- Modified `constants ` to be consistent with the new package name.