### PR TITLE
#148 Clear NEAR Wallet KeyStore

### DIFF
--- a/src/wallets/browser/NearWallet.ts
+++ b/src/wallets/browser/NearWallet.ts
@@ -23,6 +23,7 @@ import {
 } from "../Wallet";
 
 class NearWallet implements BrowserWallet {
+  private keyStore: keyStores.KeyStore;
   private wallet: WalletConnection;
 
   private options: Options;
@@ -44,13 +45,15 @@ class NearWallet implements BrowserWallet {
   };
 
   init = async () => {
+    const keyStore = new keyStores.BrowserLocalStorageKeyStore();
     const near = await connect({
-      keyStore: new keyStores.BrowserLocalStorageKeyStore(),
+      keyStore,
       ...getConfig(this.options.networkId),
       headers: {},
     });
 
     this.wallet = new WalletConnection(near, "near_app");
+    this.keyStore = keyStore;
   };
 
   // We don't emit "signIn" or update state as we can't guarantee the user will
@@ -75,6 +78,7 @@ class NearWallet implements BrowserWallet {
     }
 
     this.wallet.signOut();
+    await this.keyStore.clear();
 
     setSelectedWalletId(null);
     this.emitter.emit("signOut");


### PR DESCRIPTION
## This PR Includes

- Fixed a bug where `signOut` didn't clean up keys generated by `near-api-js`.

## Notes

- You could argue this is a really a bug with `near-api-js` (since it creates keys in storage), but since we pass the `keyStore` as a parameter, we can do the cleanup ourselves for now.