### PR TITLE
feat: sender wallet API change

### DIFF
--- a/src/interfaces/InjectedSenderWallet.ts
+++ b/src/interfaces/InjectedSenderWallet.ts
@@ -41,8 +41,6 @@ export interface RequestSignInParams {
   amount?: string; // in yoctoⓃ
 }
 
-export type Callback = (response: any) => void;
-
 export interface RpcChangedResponse {
   method: "rpcChanged";
   notificationId: number;
@@ -86,6 +84,13 @@ export interface RequestSignTransactionsParams {
   transactions: Array<Transaction>;
 }
 
+export interface SenderWalletEvents {
+  signIn: () => void;
+  signOut: () => void;
+  accountChanged: (changedAccountId: string) => void;
+  rpcChanged: (response: RpcChangedResponse) => void;
+}
+
 interface InjectedSenderWallet {
   isSender: boolean;
   getAccountId: () => string;
@@ -95,7 +100,10 @@ interface InjectedSenderWallet {
   ) => Promise<RequestSignInResponse>;
   signOut: () => boolean;
   isSignedIn: () => boolean;
-  on: (event: string, callback: Callback) => void;
+  on: <Event extends keyof SenderWalletEvents>(
+    event: Event,
+    callback: SenderWalletEvents[Event]
+  ) => void;
   // TODO: Determine return type.
   sendMoney: (params: SendMoneyParams) => Promise<unknown>;
   signAndSendTransaction: (

--- a/src/interfaces/InjectedSenderWallet.ts
+++ b/src/interfaces/InjectedSenderWallet.ts
@@ -40,11 +40,6 @@ export interface RequestSignInParams {
   methodNames?: Array<string>;
 }
 
-export interface SignOutResponse {
-  // TODO: Figure out when this isn't "success".
-  result: "success";
-}
-
 export type Callback = (response: any) => void;
 
 export interface RpcChangedResponse {
@@ -91,13 +86,13 @@ export interface RequestSignTransactionsParams {
 }
 
 interface InjectedSenderWallet {
-  isSender: string,
+  isSender: boolean,
   getAccountId: () => string;
   getRpc: () => Promise<GetRpcResponse>;
   requestSignIn: (
     params: RequestSignInParams
   ) => Promise<RequestSignInResponse>;
-  signOut: () => SignOutResponse;
+  signOut: () => boolean;
   isSignedIn: () => boolean;
   on: (event: string, callback: Callback) => void;
   // TODO: Determine return type.

--- a/src/interfaces/InjectedSenderWallet.ts
+++ b/src/interfaces/InjectedSenderWallet.ts
@@ -38,6 +38,7 @@ export interface GetRpcResponse {
 export interface RequestSignInParams {
   contractId: string;
   methodNames?: Array<string>;
+  amount?: string; // in yoctoⓃ
 }
 
 export type Callback = (response: any) => void;

--- a/src/interfaces/InjectedSenderWallet.ts
+++ b/src/interfaces/InjectedSenderWallet.ts
@@ -1,9 +1,5 @@
 // Interfaces based on "documentation": https://github.com/SenderWallet/sender-wallet-integration-tutorial
 
-export interface InitParams {
-  contractId: string;
-}
-
 // Empty string if we haven't signed in before.
 interface AccessKey {
   publicKey: {
@@ -11,10 +7,6 @@ interface AccessKey {
     keyType: number;
   };
   secretKey: string;
-}
-
-export interface InitResponse {
-  accessKey: AccessKey | "";
 }
 
 export interface RequestSignInResponse {
@@ -53,7 +45,7 @@ export interface SignOutResponse {
   result: "success";
 }
 
-export type AccountChangedCallback = (newAccountId: string) => void;
+export type Callback = (response: any) => void;
 
 export interface RpcChangedResponse {
   method: "rpcChanged";
@@ -61,8 +53,6 @@ export interface RpcChangedResponse {
   rpc: RpcInfo;
   type: "sender-wallet-fromContent";
 }
-
-export type RpcChangedCallback = (newRpc: RpcChangedResponse) => void;
 
 export interface SendMoneyParams {
   receiverId: string;
@@ -101,16 +91,15 @@ export interface RequestSignTransactionsParams {
 }
 
 interface InjectedSenderWallet {
-  init: (params: InitParams) => Promise<InitResponse>;
+  isSender: string,
   getAccountId: () => string;
   getRpc: () => Promise<GetRpcResponse>;
   requestSignIn: (
     params: RequestSignInParams
   ) => Promise<RequestSignInResponse>;
-  signOut: () => Promise<SignOutResponse>;
+  signOut: () => SignOutResponse;
   isSignedIn: () => boolean;
-  onAccountChanged: (callback: AccountChangedCallback) => void;
-  onRpcChanged: (callback: RpcChangedCallback) => void;
+  on: (event: string, callback: Callback) => void;
   // TODO: Determine return type.
   sendMoney: (params: SendMoneyParams) => Promise<unknown>;
   signAndSendTransaction: (

--- a/src/interfaces/InjectedSenderWallet.ts
+++ b/src/interfaces/InjectedSenderWallet.ts
@@ -86,7 +86,7 @@ export interface RequestSignTransactionsParams {
 }
 
 interface InjectedSenderWallet {
-  isSender: boolean,
+  isSender: boolean;
   getAccountId: () => string;
   getRpc: () => Promise<GetRpcResponse>;
   requestSignIn: (

--- a/src/wallets/injected/SenderWallet.ts
+++ b/src/wallets/injected/SenderWallet.ts
@@ -70,7 +70,7 @@ class SenderWallet implements InjectedWallet {
 
     this.onAccountChanged();
 
-    this.wallet.on('rpcChanged', (response) => {
+    this.wallet.on("rpcChanged", (response) => {
       this.networkMatches(response);
     });
   };
@@ -118,7 +118,7 @@ class SenderWallet implements InjectedWallet {
   };
 
   private onAccountChanged = () => {
-    this.wallet.on('accountChanged', async (newAccountId) => {
+    this.wallet.on("accountChanged", async (newAccountId) => {
       logger.log("SenderWallet:onAccountChange", newAccountId);
 
       try {

--- a/src/wallets/injected/SenderWallet.ts
+++ b/src/wallets/injected/SenderWallet.ts
@@ -137,7 +137,7 @@ class SenderWallet implements InjectedWallet {
   signOut = async () => {
     const res = this.wallet.signOut();
 
-    if (res.result !== "success") {
+    if (res) {
       throw new Error("Failed to sign out");
     }
 

--- a/src/wallets/injected/SenderWallet.ts
+++ b/src/wallets/injected/SenderWallet.ts
@@ -137,7 +137,7 @@ class SenderWallet implements InjectedWallet {
   signOut = async () => {
     const res = this.wallet.signOut();
 
-    if (res) {
+    if (!res) {
       throw new Error("Failed to sign out");
     }
 

--- a/src/wallets/injected/SenderWallet.ts
+++ b/src/wallets/injected/SenderWallet.ts
@@ -90,7 +90,6 @@ class SenderWallet implements InjectedWallet {
 
     const { accessKey } = await this.wallet.requestSignIn({
       contractId: this.options.contract.accountId,
-      methodNames: this.options.contract.changeMethods || [],
     });
 
     if (!accessKey) {

--- a/src/wallets/injected/SenderWallet.ts
+++ b/src/wallets/injected/SenderWallet.ts
@@ -56,7 +56,7 @@ class SenderWallet implements InjectedWallet {
   };
 
   private isInstalled = () => {
-    return typeof window.near !== 'undefined' && window.near.isSender;
+    return !!window.near?.isSender;
   };
 
   init = async () => {


### PR DESCRIPTION
Fixes: #157 

Due to the recent Sender API change (as documented here: https://docs.senderwallet.io/api-reference/near-provider-api), `near-wallet-selector` needs to be updated to work well with the latest version. 

A relevant idea is to maintain versioned implementations which could be loaded, by detecting the version of the installed extension wallet, but this is not high-priority since we prefer to standardize and stabilize the wallet SDKs.

