### PR TITLE
Fix typescript missing dependency in Angular Example

### DIFF
--- a/examples/angular/package.json
+++ b/examples/angular/package.json
@@ -27,6 +27,7 @@
     "@angular-devkit/build-angular": "~13.2.4",
     "@angular/cli": "~13.2.4",
     "@angular/compiler-cli": "~13.2.0",
-    "@types/node": "^12.11.1"
+    "@types/node": "^12.11.1",
+    "typescript": "~4.5.2"
   }
 }

--- a/examples/angular/yarn.lock
+++ b/examples/angular/yarn.lock
@@ -6113,6 +6113,11 @@ typed-assert@^1.0.8:
   resolved "https://registry.yarnpkg.com/typed-assert/-/typed-assert-1.0.9.tgz#8af9d4f93432c4970ec717e3006f33f135b06213"
   integrity sha512-KNNZtayBCtmnNmbo5mG47p1XsCyrx6iVqomjcZnec/1Y5GGARaxPs6r49RnSPeUP3YjNYiU9sQHAtY4BBvnZwg==
 
+typescript@~4.5.2:
+  version "4.5.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
+  integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
+
 u3@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/u3/-/u3-0.1.1.tgz#5f52044f42ee76cd8de33148829e14528494b73b"


### PR DESCRIPTION
## This PR includes
- Typescript version  "~4.5.2" added as a devDependency.

## Notes
The angular example works on the current location just fine.

With this PR I am trying to address the possibility when someone copies this example somewhere outside the location `"wallet-selector/examples/angular"`.
I noticed that after running `"yarn start"` angular cli can't find typescript module if it is outside the wallet-selector folder.