### PR TITLE
#173 Unify Sign In Functionality Across Wallets

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Sign in (programmatically):
 ```ts
 // NEAR Wallet.
 await selector.signIn({
- walletId: "near-wallet"
+  walletId: "near-wallet"
 });
 
 // Sender Wallet.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ const selector = new NearWalletSelector({
       "added to your browser, a hardware device plugged into your",
       "computer, web-based, or as an app on your phone.",
     ].join(" "),
-  }
+  },
 });
 ```
 
@@ -76,12 +76,12 @@ Sign in (programmatically):
 ```ts
 // NEAR Wallet.
 await selector.signIn({
-  walletId: "near-wallet"
+  walletId: "near-wallet",
 });
 
 // Sender Wallet.
 await selector.signIn({
-  walletId: "sender-wallet"
+  walletId: "sender-wallet",
 });
 
 // Ledger Wallet
@@ -153,10 +153,10 @@ await selector.contract.signAndSendTransaction({
     type: "FunctionCall",
     params: {
       methodName: "addMessage",
-      args: {text: message.value},
+      args: { text: "Hello World!" },
       gas: "30000000000000",
-      deposit: "10000000000000000000000"
-    }
+      deposit: "10000000000000000000000",
+    },
   }]
 });
 
@@ -200,7 +200,7 @@ const near = new NearWalletSelector({
   walletSelectorUI: {
     description: "Add your own description",
     explanation: "Add your own wallet explanation",
-  }
+  },
 });
 ```
 ## Contributing 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Then use it in your dApp:
 ```ts
 import NearWalletSelector from "near-wallet-selector";
 
-const near = new NearWalletSelector({
+const selector = new NearWalletSelector({
   wallets: ["near-wallet", "sender-wallet", "ledger-wallet"],
   networkId: "testnet",
   theme: "light",
@@ -56,54 +56,69 @@ const near = new NearWalletSelector({
 Init:
 
 ```ts
-await near.init();
+await selector.init();
 ```
 
 Show modal:
 
 ```ts
-near.show();
+selector.show();
 ```
 
 Hide modal:
 
 ```ts
-near.hide();
+selector.hide();
 ```
 
 Sign in (programmatically):
 
 ```ts
-await near.signIn("near-wallet");
+// NEAR Wallet.
+await selector.signIn({
+ walletId: "near-wallet"
+});
+
+// Sender Wallet.
+await selector.signIn({
+  walletId: "sender-wallet"
+});
+
+// Ledger Wallet
+await selector.signIn({
+  walletId: "ledger-wallet",
+  accountId: "account-id.testnet",
+  derviationPath: "44'/397'/0'/0'/1'",
+});
 ```
 
 Sign out:
 
 ```ts
-await near.signOut();
+await selector.signOut();
 ```
 
 Is signed in:
 
 ```ts
-await near.isSignedIn();
+await selector.isSignedIn();
 ```
 
 Get account:
 
 ```ts
-const account = await near.getAccount();
+const account = await selector.getAccount();
 ```
 
 Add event listeners:
 
 ```ts
-near.on("signIn", () => {
-   // your code
+selector.on("signIn", () => {
+  // Your code here.
 });
 
-near.on("signOut", () => {
-  // your code
+selector.on("signOut", () => {
+  // Your code here.
 });
 ```
 
@@ -111,29 +126,29 @@ Remove event listeners:
 
 ```ts
 // Method 1:
-const subscription = near.on("signIn", () => {
-   // your code
+const subscription = selector.on("signIn", () => {
+  // Your code here.
 });
 
 subscription.remove();
 
 // Method 2:
 const handleSignIn = () => {
-  // your code
+  // Your code here.
 }
 
-near.on("signIn", handleSignIn);
-near.off("signIn", handleSignIn);
+selector.on("signIn", handleSignIn);
+selector.off("signIn", handleSignIn);
 ```
 
 Interact with the Smart Contract:
 
 ```ts
 // Retrieve messages via RPC endpoint (view method).
-const messages = await near.contract.view({ methodName: "getMessages" });
+const messages = await selector.contract.view({ methodName: "getMessages" });
 
 // Add a message, modifying the blockchain (change method).
-await near.contract.signAndSendTransaction({
+await selector.contract.signAndSendTransaction({
   actions: [{
     type: "FunctionCall",
     params: {
@@ -146,7 +161,7 @@ await near.contract.signAndSendTransaction({
 });
 
 // Retrieve contract accountId.
-const accountId = near.contract.getAccountId();
+const accountId = selector.contract.getAccountId();
 ```
 
 ## Custom Themes

--- a/examples/angular/src/app/app.component.ts
+++ b/examples/angular/src/app/app.component.ts
@@ -18,7 +18,7 @@ export class AppComponent implements OnInit {
   async initialize() {
     const nearConfig = getConfig("testnet");
 
-    const nearWalletSelector = new NearWalletSelector({
+    const selector = new NearWalletSelector({
       wallets: ["near-wallet", "sender-wallet", "ledger-wallet"],
       networkId: "testnet",
       theme: "light",
@@ -35,8 +35,12 @@ export class AppComponent implements OnInit {
         ].join(" "),
       },
     });
-    await nearWalletSelector.init();
 
-    this.selector = nearWalletSelector;
+    // @ts-ignore
+    window.selector = selector;
+
+    await selector.init();
+
+    this.selector = selector;
   }
 }

--- a/examples/react/src/App.tsx
+++ b/examples/react/src/App.tsx
@@ -12,7 +12,7 @@ const App: React.FC = () => {
   useEffect(() => {
     const nearConfig = getConfig("testnet");
 
-    const nearWalletSelector = new NearWalletSelector({
+    const selector = new NearWalletSelector({
       wallets: ["near-wallet", "sender-wallet", "ledger-wallet"],
       networkId: "testnet",
       theme: "light",
@@ -30,8 +30,11 @@ const App: React.FC = () => {
       },
     });
 
-    nearWalletSelector.init().then(() => {
-      selectorRef.current = nearWalletSelector;
+    // @ts-ignore
+    window.selector = selector;
+
+    selector.init().then(() => {
+      selectorRef.current = selector;
       setLoaded(true);
     });
 

--- a/examples/vue/src/App.vue
+++ b/examples/vue/src/App.vue
@@ -5,12 +5,12 @@ import NearWalletSelector from "near-wallet-selector";
 import getConfig from "./config";
 import Content from "./components/Content.vue";
 
-const selector = shallowRef<NearWalletSelector>();
+const selectorRef = shallowRef<NearWalletSelector>();
 
 onMounted(async () => {
   const nearConfig = getConfig("testnet");
 
-  const nearWalletSelector = new NearWalletSelector({
+  const selector = new NearWalletSelector({
     wallets: ["near-wallet", "sender-wallet", "ledger-wallet"],
     networkId: "testnet",
     theme: "light",
@@ -28,15 +28,18 @@ onMounted(async () => {
     },
   });
 
-  await nearWalletSelector.init();
+  // @ts-ignore
+  window.selector = selector;
 
-  selector.value = nearWalletSelector;
+  await selector.init();
+
+  selectorRef.value = selector;
 });
 </script>
 
 <template>
   <h1>NEAR Guest Book</h1>
-  <Content v-if="!!selector" :selector="selector" />
+  <Content v-if="!!selectorRef" :selector="selectorRef" />
 </template>
 
 <style>

--- a/src/controllers/WalletController.ts
+++ b/src/controllers/WalletController.ts
@@ -33,7 +33,7 @@ class WalletController {
     return wallets.map((wallet) => {
       return {
         ...wallet,
-        signIn: async (x: never) => {
+        signIn: async (params: never) => {
           const selectedWallet = this.getSelectedWallet();
 
           if (selectedWallet) {
@@ -44,7 +44,7 @@ class WalletController {
             await selectedWallet.signOut();
           }
 
-          return wallet.signIn(x);
+          return wallet.signIn(params);
         },
       };
     });

--- a/src/controllers/WalletController.ts
+++ b/src/controllers/WalletController.ts
@@ -8,6 +8,12 @@ import { BuiltInWalletId, Options } from "../core/NearWalletSelector";
 import { Emitter } from "../utils/EventsHandler";
 import { LOCAL_STORAGE_SELECTED_WALLET_ID } from "../constants";
 
+export interface SignInParams {
+  walletId: BuiltInWalletId;
+  accountId?: string;
+  derivationPath?: string;
+}
+
 class WalletController {
   private options: Options;
   private provider: ProviderService;
@@ -27,7 +33,7 @@ class WalletController {
     return wallets.map((wallet) => {
       return {
         ...wallet,
-        signIn: async () => {
+        signIn: async (x: never) => {
           const selectedWallet = this.getSelectedWallet();
 
           if (selectedWallet) {
@@ -38,7 +44,7 @@ class WalletController {
             await selectedWallet.signOut();
           }
 
-          return wallet.signIn();
+          return wallet.signIn(x);
         },
       };
     });
@@ -122,11 +128,23 @@ class WalletController {
     return this.wallets;
   }
 
-  async signIn(walletId: BuiltInWalletId) {
+  async signIn({ walletId, accountId, derivationPath }: SignInParams) {
     const wallet = this.getWallet(walletId);
 
     if (!wallet) {
-      throw new Error(`Invalid built-in wallet '${walletId}'`);
+      throw new Error(`Invalid wallet '${walletId}'`);
+    }
+
+    if (wallet.type === "hardware") {
+      if (!accountId) {
+        throw new Error("Invalid account id");
+      }
+
+      if (!derivationPath) {
+        throw new Error("Invalid derivation path");
+      }
+
+      return wallet.signIn({ accountId, derivationPath });
     }
 
     return wallet.signIn();

--- a/src/core/NearWalletSelector.tsx
+++ b/src/core/NearWalletSelector.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 import ReactDOM from "react-dom";
 
-import WalletController from "../controllers/WalletController";
+import WalletController, {
+  SignInParams,
+} from "../controllers/WalletController";
 import Contract from "./Contract";
 import Modal from "../modal/Modal";
 import EventHandler, { Emitter, EventList } from "../utils/EventsHandler";
@@ -84,8 +86,8 @@ export default class NearWalletSelector {
     }));
   }
 
-  signIn(walletId: BuiltInWalletId) {
-    return this.controller.signIn(walletId);
+  signIn(params: SignInParams) {
+    return this.controller.signIn(params);
   }
 
   signOut() {

--- a/src/modal/Modal.tsx
+++ b/src/modal/Modal.tsx
@@ -106,11 +106,11 @@ const Modal: React.FC<ModalProps> = ({ options, wallets }) => {
       (x) => x.id === "ledger-wallet"
     ) as HardwareWallet;
 
-    wallet.setDerivationPath(ledgerDerivationPath);
-    wallet.setAccountId(ledgerAccountId);
-
     await wallet
-      .signIn()
+      .signIn({
+        accountId: ledgerAccountId,
+        derivationPath: ledgerDerivationPath,
+      })
       .catch((err) => setLedgerError(`Error: ${err.message}`));
 
     resetState();

--- a/src/wallets/Wallet.ts
+++ b/src/wallets/Wallet.ts
@@ -9,6 +9,11 @@ export interface WalletOptions {
   emitter: Emitter;
 }
 
+export interface HardwareWalletSignInParams {
+  accountId: string;
+  derivationPath: string;
+}
+
 export interface SignAndSendTransactionParams {
   receiverId: string;
   actions: Array<Action>;
@@ -42,7 +47,7 @@ interface BaseWallet {
 
   // Requests sign in for the given wallet.
   // Note: Hardware wallets should defer HID connection until user input is required (e.g. public key or signing).
-  signIn(): Promise<void>;
+  signIn(params?: object): Promise<void>;
 
   // Removes connection to the wallet and triggers a cleanup of subscriptions etc.
   signOut(): Promise<void>;
@@ -70,8 +75,7 @@ export interface InjectedWallet extends BaseWallet {
 
 export interface HardwareWallet extends BaseWallet {
   type: "hardware";
-  setAccountId(accountId: string): void;
-  setDerivationPath(derivationPath: string): void;
+  signIn(params: HardwareWalletSignInParams): Promise<void>;
 }
 
 export type Wallet = BrowserWallet | InjectedWallet | HardwareWallet;


### PR DESCRIPTION
## This PR Includes

- `signIn` now takes hardware wallet specific parameters, removing the need for additional state in `LedgerWallet` and `setAccountId` and `setDerivationPath`.
- Updated README to reflect changes.
- Exported library to the `window` in each example for "headless" testing such as this `signIn` method.