### PR TITLE
Options Refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,22 +33,39 @@ import NearWalletSelector from "near-wallet-selector";
 const near = new NearWalletSelector({
   wallets: ["near-wallet", "sender-wallet", "ledger-wallet"],
   networkId: "testnet",
-  theme: "light",
   contract: {
     accountId: "guest-book.testnet",
-    viewMethods: ["getMessages"],
-    changeMethods: ["addMessage"],
+    methodNames: ["getMessages", "addMessage"],
   },
-  walletSelectorUI: {
+  ui: {
+    theme: "light",
     description: "Please select a wallet to connect to this dApp:",
-    explanation: [
-      "Wallets are used to send, receive, and store digital assets.",
-      "There are different types of wallets. They can be an extension",
-      "added to your browser, a hardware device plugged into your",
-      "computer, web-based, or as an app on your phone.",
-    ].join(" "),
-  }
+  },
 });
+```
+
+## Options
+
+```ts
+interface Options {
+  // List of wallets you want to support in your dApp.
+  wallets: Array<"near-wallet" | "sender-wallet" | "ledger-wallet">;
+  // Network ID matching that of your dApp.
+  networkId: "mainnet" | "betanet" | "testnet";
+  contract: {
+    // Account ID of the Smart Contract used for 'view' and 'signAndSendTransaction' calls.
+    contractId: string;
+    // Optional: Specify limited access to particular methods on the Smart Contract.
+    methodNames?: Array<string>;
+  };
+  ui?: {
+    // Optional: Specify light/dark theme for UI. Defaults to the browser configuration when
+    // omitted or set to 'auto'.
+    theme?: "dark" | "light" | "auto";
+    // Optional: Provides customisation description text in the UI.
+    description?: string;
+  };
+}
 ```
 
 ## API Reference
@@ -146,48 +163,9 @@ await near.contract.signAndSendTransaction({
 });
 
 // Retrieve contract accountId.
-const accountId = near.contract.getAccountId();
+const accountId = near.contract.getContractId();
 ```
 
-## Custom Themes
-
-If no value is provided for `theme` option then the theme will be picked by System's default mode/theme.
-
-There are two available themes `light` and `dark`:
-
-To use the `light` mode, add `theme` option with the value `light`
-
-```ts
-const near = new NearWalletSelector({
-  ...otherOptions,
-  theme: "light",
-});
-```
-
-To use the `dark` mode, add `theme` option with the value `dark`
-
-```ts
-const near = new NearWalletSelector({
-  ...otherOptions,
-  theme: "dark",
-});
-```
-## Custom/Optional UI Elements
-
-The `walletSelectorUI` option provides two properties which help to modify/customize the UI:
-
-- The `description` property if provided replaces the default description.
-- The `explanation` property if provided shows **What is a wallet?** section, if not provided there is no default wallet explanation the section will be hidden.
-
-```ts
-const near = new NearWalletSelector({
-  ...otherOptions,
-  walletSelectorUI: {
-    description: "Add your own description",
-    explanation: "Add your own wallet explanation",
-  }
-});
-```
 ## Contributing 
 
 Contributors may find the [`examples`](./examples) directory useful as it provides a quick and consistent way to manually test new changes and/or bug fixes. Below is a common workflow you can use:

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ import NearWalletSelector from "near-wallet-selector";
 const near = new NearWalletSelector({
   wallets: ["near-wallet", "sender-wallet", "ledger-wallet"],
   networkId: "testnet",
-  contract: { accountId: "guest-book.testnet" },
+  contract: { contractId: "guest-book.testnet" },
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -33,14 +33,7 @@ import NearWalletSelector from "near-wallet-selector";
 const near = new NearWalletSelector({
   wallets: ["near-wallet", "sender-wallet", "ledger-wallet"],
   networkId: "testnet",
-  contract: {
-    accountId: "guest-book.testnet",
-    methodNames: ["getMessages", "addMessage"],
-  },
-  ui: {
-    theme: "light",
-    description: "Please select a wallet to connect to this dApp:",
-  },
+  contract: { accountId: "guest-book.testnet" },
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -47,11 +47,15 @@ const near = new NearWalletSelector({
 ## Options
 
 ```ts
+type BuiltInWalletId = "near-wallet" | "sender-wallet" | "ledger-wallet";
+type NetworkId = "mainnet" | "betanet" | "testnet";
+type Theme = "dark" | "light" | "auto";
+
 interface Options {
   // List of wallets you want to support in your dApp.
-  wallets: Array<"near-wallet" | "sender-wallet" | "ledger-wallet">;
+  wallets: Array<BuiltInWalletId>;
   // Network ID matching that of your dApp.
-  networkId: "mainnet" | "betanet" | "testnet";
+  networkId: NetworkId;
   contract: {
     // Account ID of the Smart Contract used for 'view' and 'signAndSendTransaction' calls.
     contractId: string;
@@ -61,7 +65,7 @@ interface Options {
   ui?: {
     // Optional: Specify light/dark theme for UI. Defaults to the browser configuration when
     // omitted or set to 'auto'.
-    theme?: "dark" | "light" | "auto";
+    theme?: Theme;
     // Optional: Provides customisation description text in the UI.
     description?: string;
   };

--- a/examples/angular/src/app/app.component.ts
+++ b/examples/angular/src/app/app.component.ts
@@ -20,20 +20,8 @@ export class AppComponent implements OnInit {
 
     const nearWalletSelector = new NearWalletSelector({
       wallets: ["near-wallet", "sender-wallet", "ledger-wallet"],
-      networkId: "testnet",
-      theme: "light",
-      contract: {
-        accountId: nearConfig.contractName,
-      },
-      walletSelectorUI: {
-        description: "Please select a wallet to connect to this dApp:",
-        explanation: [
-          "Wallets are used to send, receive, and store digital assets.",
-          "There are different types of wallets. They can be an extension",
-          "added to your browser, a hardware device plugged into your",
-          "computer, web-based, or as an app on your phone.",
-        ].join(" "),
-      },
+      networkId: nearConfig.networkId,
+      contract: { contractId: nearConfig.contractName },
     });
     await nearWalletSelector.init();
 

--- a/examples/angular/src/config.ts
+++ b/examples/angular/src/config.ts
@@ -1,33 +1,43 @@
+import { Options } from "near-wallet-selector";
+
 const CONTRACT_NAME = "guest-book.testnet";
 
-const getConfig = (env: string) => {
-  switch (env) {
+interface Configuration {
+  networkId: Options["networkId"];
+  contractName: string;
+  nodeUrl: string;
+  walletUrl: string;
+  helperUrl: string;
+}
+
+const getConfig = (networkId: Options["networkId"]): Configuration => {
+  switch (networkId) {
     case "mainnet":
       return {
-        networkId: "mainnet",
+        networkId,
         nodeUrl: "https://rpc.mainnet.near.org",
         contractName: CONTRACT_NAME,
         walletUrl: "https://wallet.near.org",
         helperUrl: "https://helper.mainnet.near.org",
       };
-    case "testnet":
-      return {
-        networkId: "testnet",
-        nodeUrl: "https://rpc.testnet.near.org",
-        contractName: CONTRACT_NAME,
-        walletUrl: "https://wallet.testnet.near.org",
-        helperUrl: "https://helper.testnet.near.org",
-      };
     case "betanet":
       return {
-        networkId: "betanet",
+        networkId,
         nodeUrl: "https://rpc.betanet.near.org",
         contractName: CONTRACT_NAME,
         walletUrl: "https://wallet.betanet.near.org",
         helperUrl: "https://helper.betanet.near.org",
       };
+    case "testnet":
+      return {
+        networkId,
+        nodeUrl: "https://rpc.testnet.near.org",
+        contractName: CONTRACT_NAME,
+        walletUrl: "https://wallet.testnet.near.org",
+        helperUrl: "https://helper.testnet.near.org",
+      };
     default:
-      throw Error(`Invalid environment '${env}'.`);
+      throw Error(`Invalid networkId '${networkId}'.`);
   }
 };
 

--- a/examples/react/src/App.tsx
+++ b/examples/react/src/App.tsx
@@ -14,20 +14,8 @@ const App: React.FC = () => {
 
     const nearWalletSelector = new NearWalletSelector({
       wallets: ["near-wallet", "sender-wallet", "ledger-wallet"],
-      networkId: "testnet",
-      theme: "light",
-      contract: {
-        accountId: nearConfig.contractName,
-      },
-      walletSelectorUI: {
-        description: "Please select a wallet to connect to this dApp:",
-        explanation: [
-          "Wallets are used to send, receive, and store digital assets.",
-          "There are different types of wallets. They can be an extension",
-          "added to your browser, a hardware device plugged into your",
-          "computer, web-based, or as an app on your phone.",
-        ].join(" "),
-      },
+      networkId: nearConfig.networkId,
+      contract: { contractId: nearConfig.contractName },
     });
 
     nearWalletSelector.init().then(() => {

--- a/examples/react/src/config.ts
+++ b/examples/react/src/config.ts
@@ -1,33 +1,43 @@
+import { Options } from "near-wallet-selector";
+
 const CONTRACT_NAME = "guest-book.testnet";
 
-const getConfig = (env: string) => {
-  switch (env) {
+interface Configuration {
+  networkId: Options["networkId"];
+  contractName: string;
+  nodeUrl: string;
+  walletUrl: string;
+  helperUrl: string;
+}
+
+const getConfig = (networkId: Options["networkId"]): Configuration => {
+  switch (networkId) {
     case "mainnet":
       return {
-        networkId: "mainnet",
+        networkId,
         nodeUrl: "https://rpc.mainnet.near.org",
         contractName: CONTRACT_NAME,
         walletUrl: "https://wallet.near.org",
         helperUrl: "https://helper.mainnet.near.org",
       };
-    case "testnet":
-      return {
-        networkId: "testnet",
-        nodeUrl: "https://rpc.testnet.near.org",
-        contractName: CONTRACT_NAME,
-        walletUrl: "https://wallet.testnet.near.org",
-        helperUrl: "https://helper.testnet.near.org",
-      };
     case "betanet":
       return {
-        networkId: "betanet",
+        networkId,
         nodeUrl: "https://rpc.betanet.near.org",
         contractName: CONTRACT_NAME,
         walletUrl: "https://wallet.betanet.near.org",
         helperUrl: "https://helper.betanet.near.org",
       };
+    case "testnet":
+      return {
+        networkId,
+        nodeUrl: "https://rpc.testnet.near.org",
+        contractName: CONTRACT_NAME,
+        walletUrl: "https://wallet.testnet.near.org",
+        helperUrl: "https://helper.testnet.near.org",
+      };
     default:
-      throw Error(`Invalid environment '${env}'.`);
+      throw Error(`Invalid networkId '${networkId}'.`);
   }
 };
 

--- a/examples/vue/src/App.vue
+++ b/examples/vue/src/App.vue
@@ -12,20 +12,8 @@ onMounted(async () => {
 
   const nearWalletSelector = new NearWalletSelector({
     wallets: ["near-wallet", "sender-wallet", "ledger-wallet"],
-    networkId: "testnet",
-    theme: "light",
-    contract: {
-      accountId: nearConfig.contractName,
-    },
-    walletSelectorUI: {
-      description: "Please select a wallet to connect to this dApp:",
-      explanation: [
-        "Wallets are used to send, receive, and store digital assets.",
-        "There are different types of wallets. They can be an extension",
-        "added to your browser, a hardware device plugged into your",
-        "computer, web-based, or as an app on your phone.",
-      ].join(" "),
-    },
+    networkId: nearConfig.networkId,
+    contract: { contractId: nearConfig.contractName },
   });
 
   await nearWalletSelector.init();

--- a/examples/vue/src/config.ts
+++ b/examples/vue/src/config.ts
@@ -1,33 +1,43 @@
+import { Options } from "near-wallet-selector";
+
 const CONTRACT_NAME = "guest-book.testnet";
 
-const getConfig = (env: string) => {
-  switch (env) {
+interface Configuration {
+  networkId: Options["networkId"];
+  contractName: string;
+  nodeUrl: string;
+  walletUrl: string;
+  helperUrl: string;
+}
+
+const getConfig = (networkId: Options["networkId"]): Configuration => {
+  switch (networkId) {
     case "mainnet":
       return {
-        networkId: "mainnet",
+        networkId,
         nodeUrl: "https://rpc.mainnet.near.org",
         contractName: CONTRACT_NAME,
         walletUrl: "https://wallet.near.org",
         helperUrl: "https://helper.mainnet.near.org",
       };
-    case "testnet":
-      return {
-        networkId: "testnet",
-        nodeUrl: "https://rpc.testnet.near.org",
-        contractName: CONTRACT_NAME,
-        walletUrl: "https://wallet.testnet.near.org",
-        helperUrl: "https://helper.testnet.near.org",
-      };
     case "betanet":
       return {
-        networkId: "betanet",
+        networkId,
         nodeUrl: "https://rpc.betanet.near.org",
         contractName: CONTRACT_NAME,
         walletUrl: "https://wallet.betanet.near.org",
         helperUrl: "https://helper.betanet.near.org",
       };
+    case "testnet":
+      return {
+        networkId,
+        nodeUrl: "https://rpc.testnet.near.org",
+        contractName: CONTRACT_NAME,
+        walletUrl: "https://wallet.testnet.near.org",
+        helperUrl: "https://helper.testnet.near.org",
+      };
     default:
-      throw Error(`Invalid environment '${env}'.`);
+      throw Error(`Invalid networkId '${networkId}'.`);
   }
 };
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-export type NetworkId = "mainnet" | "testnet" | "betanet";
+import { NetworkId } from "./interfaces/Options";
 
 export interface NetworkConfiguration {
   networkId: NetworkId;

--- a/src/controllers/WalletController.ts
+++ b/src/controllers/WalletController.ts
@@ -4,7 +4,7 @@ import SenderWallet from "../wallets/injected/SenderWallet";
 import LedgerWallet from "../wallets/hardware/LedgerWallet";
 import ProviderService from "../services/provider/ProviderService";
 import { Wallet } from "../wallets/Wallet";
-import { BuiltInWalletId, Options } from "../core/NearWalletSelector";
+import { BuiltInWalletId, Options } from "../interfaces/Options";
 import { Emitter } from "../utils/EventsHandler";
 import { LOCAL_STORAGE_SELECTED_WALLET_ID } from "../constants";
 

--- a/src/core/Contract.ts
+++ b/src/core/Contract.ts
@@ -2,7 +2,7 @@ import ProviderService, {
   CallFunctionParams,
 } from "../services/provider/ProviderService";
 import WalletController from "../controllers/WalletController";
-import { Options } from "./NearWalletSelector";
+import { Options } from "../interfaces/Options";
 import { SignAndSendTransactionParams } from "../wallets/Wallet";
 
 class Contract {

--- a/src/core/Contract.ts
+++ b/src/core/Contract.ts
@@ -20,13 +20,13 @@ class Contract {
     this.controller = controller;
   }
 
-  getAccountId() {
-    return this.options.contract.accountId;
+  getContractId() {
+    return this.options.contract.contractId;
   }
 
   view({ methodName, args, finality }: Omit<CallFunctionParams, "accountId">) {
     return this.provider.callFunction({
-      accountId: this.options.contract.accountId,
+      accountId: this.options.contract.contractId,
       methodName,
       args,
       finality,
@@ -43,7 +43,7 @@ class Contract {
     }
 
     return wallet.signAndSendTransaction({
-      receiverId: this.options.contract.accountId,
+      receiverId: this.options.contract.contractId,
       actions,
     });
   }

--- a/src/core/NearWalletSelector.tsx
+++ b/src/core/NearWalletSelector.tsx
@@ -11,7 +11,7 @@ import getConfig from "../config";
 import ProviderService from "../services/provider/ProviderService";
 import { updateState } from "../state/State";
 import { MODAL_ELEMENT_ID } from "../constants";
-import { BuiltInWalletId, Options } from "../interfaces/Options";
+import { Options } from "../interfaces/Options";
 
 export default class NearWalletSelector {
   private options: Options;

--- a/src/core/NearWalletSelector.tsx
+++ b/src/core/NearWalletSelector.tsx
@@ -84,10 +84,6 @@ export default class NearWalletSelector {
     return this.controller.getAccount();
   }
 
-  getWallets() {
-    return this.controller.getWallets();
-  }
-
   on(event: EventList, callback: () => void) {
     return this.emitter.on(event, callback);
   }

--- a/src/core/NearWalletSelector.tsx
+++ b/src/core/NearWalletSelector.tsx
@@ -5,26 +5,11 @@ import WalletController from "../controllers/WalletController";
 import Contract from "./Contract";
 import Modal from "../modal/Modal";
 import EventHandler, { Emitter, EventList } from "../utils/EventsHandler";
-import getConfig, { NetworkId } from "../config";
+import getConfig from "../config";
 import ProviderService from "../services/provider/ProviderService";
 import { updateState } from "../state/State";
 import { MODAL_ELEMENT_ID } from "../constants";
-
-export type BuiltInWalletId = "near-wallet" | "sender-wallet" | "ledger-wallet";
-export type UITheme = "dark" | "light";
-
-export interface Options {
-  wallets: Array<BuiltInWalletId>;
-  networkId: NetworkId;
-  contract: {
-    contractId: string;
-    methodNames?: Array<string>;
-  };
-  ui?: {
-    theme?: "dark" | "light";
-    description?: string;
-  };
-}
+import { BuiltInWalletId, Options } from "../interfaces/Options";
 
 export default class NearWalletSelector {
   private options: Options;

--- a/src/core/NearWalletSelector.tsx
+++ b/src/core/NearWalletSelector.tsx
@@ -11,19 +11,18 @@ import { updateState } from "../state/State";
 import { MODAL_ELEMENT_ID } from "../constants";
 
 export type BuiltInWalletId = "near-wallet" | "sender-wallet" | "ledger-wallet";
+export type UITheme = "dark" | "light";
 
 export interface Options {
   wallets: Array<BuiltInWalletId>;
   networkId: NetworkId;
-  theme: "dark" | "light" | null;
   contract: {
-    accountId: string;
-    viewMethods?: Array<string>;
-    changeMethods?: Array<string>;
+    contractId: string;
+    methodNames?: Array<string>;
   };
-  walletSelectorUI: {
-    description: string;
-    explanation: string;
+  ui?: {
+    theme?: "dark" | "light";
+    description?: string;
   };
 }
 
@@ -98,6 +97,10 @@ export default class NearWalletSelector {
 
   getAccount() {
     return this.controller.getAccount();
+  }
+
+  getWallets() {
+    return this.controller.getWallets();
   }
 
   on(event: EventList, callback: () => void) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import NearWalletSelector from "./core/NearWalletSelector";
 
-export { Options } from "./core/NearWalletSelector";
+export { Options } from "./interfaces/Options";
 
 export {
   Wallet,

--- a/src/interfaces/Options.ts
+++ b/src/interfaces/Options.ts
@@ -1,0 +1,16 @@
+export type BuiltInWalletId = "near-wallet" | "sender-wallet" | "ledger-wallet";
+export type NetworkId = "mainnet" | "testnet" | "betanet";
+export type Theme = "dark" | "light";
+
+export interface Options {
+  wallets: Array<BuiltInWalletId>;
+  networkId: NetworkId;
+  contract: {
+    contractId: string;
+    methodNames?: Array<string>;
+  };
+  ui?: {
+    theme?: Theme;
+    description?: string;
+  };
+}

--- a/src/interfaces/Options.ts
+++ b/src/interfaces/Options.ts
@@ -1,6 +1,6 @@
 export type BuiltInWalletId = "near-wallet" | "sender-wallet" | "ledger-wallet";
-export type NetworkId = "mainnet" | "testnet" | "betanet";
-export type Theme = "dark" | "light";
+export type NetworkId = "mainnet" | "betanet" | "testnet";
+export type Theme = "dark" | "light" | "auto";
 
 export interface Options {
   wallets: Array<BuiltInWalletId>;

--- a/src/modal/Modal.tsx
+++ b/src/modal/Modal.tsx
@@ -2,7 +2,7 @@ import React, { ChangeEvent, MouseEvent, useEffect, useState } from "react";
 import styles from "./Modal.styles";
 import { getState, updateState, State } from "../state/State";
 import { logger } from "../services/logging.service";
-import { Options } from "../core/NearWalletSelector";
+import { Options, UITheme } from "../core/NearWalletSelector";
 import { HardwareWallet, Wallet } from "../wallets/Wallet";
 import { DEFAULT_DERIVATION_PATH } from "../constants";
 
@@ -13,14 +13,13 @@ declare global {
   }
 }
 
-const getThemeClass = (theme: string | null) => {
+// TODO: Default to "auto".
+const getThemeClass = (theme?: UITheme) => {
   switch (theme) {
     case "dark":
       return "Modal-dark-theme";
-    case "light":
-      return "Modal-light-theme";
     default:
-      return "";
+      return "Modal-light-theme";
   }
 };
 
@@ -38,8 +37,6 @@ const Modal: React.FC<ModalProps> = ({ options, wallets }) => {
     DEFAULT_DERIVATION_PATH
   );
   const [isLoading, setIsLoading] = useState(false);
-
-  const defaultDescription = "Please select a wallet to connect to this dApp:";
 
   useEffect(() => {
     window.updateWalletSelector = (nextState) => {
@@ -120,7 +117,7 @@ const Modal: React.FC<ModalProps> = ({ options, wallets }) => {
     <div style={{ display: state.showModal ? "block" : "none" }}>
       <style>{styles}</style>
       <div
-        className={`Modal ${getThemeClass(options.theme)}`}
+        className={`Modal ${getThemeClass(options.ui?.theme)}`}
         onClick={handleDismissOutsideClick}
       >
         <div className="Modal-content">
@@ -144,7 +141,8 @@ const Modal: React.FC<ModalProps> = ({ options, wallets }) => {
             className="Modal-body Modal-select-wallet-option"
           >
             <p className="Modal-description">
-              {options.walletSelectorUI.description || defaultDescription}
+              {options.ui?.description ||
+                "Please select a wallet to connect to this dApp:"}
             </p>
             <ul className="Modal-option-list">
               {wallets
@@ -306,24 +304,27 @@ const Modal: React.FC<ModalProps> = ({ options, wallets }) => {
               </button>
             </div>
           </div>
-          {options.walletSelectorUI.explanation && (
-            <div className="info">
-              <span
-                onClick={() => {
-                  setWalletInfoVisible(!walletInfoVisible);
-                }}
-              >
-                What is a Wallet?
-              </span>
-              <div
-                className={`info-description ${
-                  walletInfoVisible ? "show" : "hide"
-                }-explanation`}
-              >
-                <p>{options.walletSelectorUI.explanation}</p>
-              </div>
+          <div className="info">
+            <span
+              onClick={() => {
+                setWalletInfoVisible(!walletInfoVisible);
+              }}
+            >
+              What is a Wallet?
+            </span>
+            <div
+              className={`info-description ${
+                walletInfoVisible ? "show" : "hide"
+              }-explanation`}
+            >
+              <p>
+                Wallets are used to send, receive and store digital assets.
+                There are different types of wallets. They can be an extension
+                added to your browser, a hardware device plugged into your
+                computer, web-based or an app on your mobile device.
+              </p>
             </div>
-          )}
+          </div>
         </div>
       </div>
     </div>

--- a/src/modal/Modal.tsx
+++ b/src/modal/Modal.tsx
@@ -13,13 +13,14 @@ declare global {
   }
 }
 
-// TODO: Default to "auto".
 const getThemeClass = (theme?: Theme) => {
   switch (theme) {
     case "dark":
       return "Modal-dark-theme";
-    default:
+    case "light":
       return "Modal-light-theme";
+    default:
+      return "";
   }
 };
 

--- a/src/modal/Modal.tsx
+++ b/src/modal/Modal.tsx
@@ -2,7 +2,7 @@ import React, { ChangeEvent, MouseEvent, useEffect, useState } from "react";
 import styles from "./Modal.styles";
 import { getState, updateState, State } from "../state/State";
 import { logger } from "../services/logging.service";
-import { Options, UITheme } from "../core/NearWalletSelector";
+import { Options, Theme } from "../interfaces/Options";
 import { HardwareWallet, Wallet } from "../wallets/Wallet";
 import { DEFAULT_DERIVATION_PATH } from "../constants";
 
@@ -14,7 +14,7 @@ declare global {
 }
 
 // TODO: Default to "auto".
-const getThemeClass = (theme?: UITheme) => {
+const getThemeClass = (theme?: Theme) => {
   switch (theme) {
     case "dark":
       return "Modal-dark-theme";

--- a/src/wallets/Wallet.ts
+++ b/src/wallets/Wallet.ts
@@ -1,4 +1,4 @@
-import { Options } from "../core/NearWalletSelector";
+import { Options } from "../interfaces/Options";
 import ProviderService from "../services/provider/ProviderService";
 import { Emitter } from "../utils/EventsHandler";
 import { Action } from "./actions";

--- a/src/wallets/browser/NearWallet.ts
+++ b/src/wallets/browser/NearWallet.ts
@@ -63,7 +63,10 @@ class NearWallet implements BrowserWallet {
       await this.init();
     }
 
-    await this.wallet.requestSignIn(this.options.contract.accountId);
+    await this.wallet.requestSignIn({
+      contractId: this.options.contract.contractId,
+      methodNames: this.options.contract.methodNames,
+    });
 
     localStorage.setItem(
       LOCAL_STORAGE_SELECTED_WALLET_ID,

--- a/src/wallets/browser/NearWallet.ts
+++ b/src/wallets/browser/NearWallet.ts
@@ -1,7 +1,7 @@
 import { WalletConnection, connect, keyStores } from "near-api-js";
 
 import getConfig from "../../config";
-import { Options } from "../../core/NearWalletSelector";
+import { Options } from "../../interfaces/Options";
 import { Emitter } from "../../utils/EventsHandler";
 import { logger } from "../../services/logging.service";
 import { transformActions } from "../actions";

--- a/src/wallets/injected/SenderWallet.ts
+++ b/src/wallets/injected/SenderWallet.ts
@@ -4,7 +4,7 @@ import InjectedSenderWallet, {
   GetRpcResponse,
   RpcChangedResponse,
 } from "../../interfaces/InjectedSenderWallet";
-import { Options } from "../../core/NearWalletSelector";
+import { Options } from "../../interfaces/Options";
 import ProviderService from "../../services/provider/ProviderService";
 import { Emitter } from "../../utils/EventsHandler";
 import { logger } from "../../services/logging.service";

--- a/src/wallets/injected/SenderWallet.ts
+++ b/src/wallets/injected/SenderWallet.ts
@@ -75,7 +75,7 @@ class SenderWallet implements InjectedWallet {
     });
 
     return this.wallet
-      .init({ contractId: this.options.contract.accountId })
+      .init({ contractId: this.options.contract.contractId })
       .then((res) => logger.log("SenderWallet:init", res));
   };
 
@@ -99,7 +99,8 @@ class SenderWallet implements InjectedWallet {
     }
 
     const { accessKey } = await this.wallet.requestSignIn({
-      contractId: this.options.contract.accountId,
+      contractId: this.options.contract.contractId,
+      methodNames: this.options.contract.methodNames,
     });
 
     if (!accessKey) {


### PR DESCRIPTION
## This PR Includes

- Renamed `walletSelectorUI` to `ui` and made it optional.
- Moved `theme` into `ui`.
- Removed configuration for `explanation`. I'm not sure there's really a use case for this to be customisable at this point in time. We can easily add it back in the future (without triggering a breaking change) if this assumption is wrong.
- Switched `contract.viewMethods` & `contract.changeMethods` for `contract.methodNames`. This is now passed as part of `signIn` to configure the access key.
- Renamed `contract.accountId` to `contract.contractId` to maintain consistency seen in `near-api-js` and Sender Wallet.
- Renamed `getAccountId` to `getContractId` on the Contract class.
- Added an "Options" section in the README to cover the various customisable properties.
- Simplified configuration of README demo and examples.