### PR TITLE
Fix UI text and border colors

### DIFF
--- a/src/modal/Modal.styles.ts
+++ b/src/modal/Modal.styles.ts
@@ -32,7 +32,7 @@ export default `
   box-sizing: content-box;
 }
 
-.Modal.Modal-light-theme {
+.Modal, .Modal.Modal-light-theme {
   color: var(--text-color);
 }
 


### PR DESCRIPTION
## This PR includes

- Fix: text color is now applied properly when no theme is provided in options.


## Notes

Since it was just 1 commit I did not open an issue for it.
The problem was when no theme is provided and the OS/Browser is configured to use system's Light mode then the text color was not applied properly, and also the border of buttons was not applied properly.