### PR TITLE
Fix Sender Wallet Interface

### DIFF
--- a/src/interfaces/InjectedSenderWallet.ts
+++ b/src/interfaces/InjectedSenderWallet.ts
@@ -73,7 +73,7 @@ export interface SignAndSendTransactionResponse {
   method: "signAndSendTransactions";
   notificationId: number;
   error?: string;
-  responses?: Array<FinalExecutionOutcome>;
+  response?: Array<FinalExecutionOutcome>;
   type: "sender-wallet-extensionResult";
 }
 

--- a/src/wallets/injected/SenderWallet.ts
+++ b/src/wallets/injected/SenderWallet.ts
@@ -197,11 +197,11 @@ class SenderWallet implements InjectedWallet {
         }
 
         // Shouldn't happen but avoids inconsistent responses.
-        if (!res.responses?.length) {
+        if (!res.response?.length) {
           throw new Error("Invalid response");
         }
 
-        return res.responses[0];
+        return res.response[0];
       });
   };
 }


### PR DESCRIPTION
## This PR Includes

- Corrected `responses` property to `response`. This was causing `signAndSendTransaction` to fail when successful.